### PR TITLE
remove unnecessary permissions in AndroidManifest.xml

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.evilthreads.evademe">
-    <uses-permission android:name="android.permission.READ_SMS"/>
     <uses-permission android:name="android.ACCESS_BACKGROUND_LOCATION"/>
-    <uses-permission android:name="android.permission.INTERNET"/>
     <application
         android:usesCleartextTraffic="true"
         android:allowBackup="true"


### PR DESCRIPTION
- remove unnecessary permissions in AndroidManifest.xml
  - these permissions are merged from pickpocket and smsbackdoor libraries